### PR TITLE
Develop/1.1.0

### DIFF
--- a/ChangesInput.html
+++ b/ChangesInput.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base target="_top">
+    <style>
+      body {
+        font-family: sans-serif;
+        padding: 15px;
+        background-color: #f5f5f5;
+      }
+      textarea {
+        width: 100%;
+        height: 150px;
+        box-sizing: border-box;
+        border: 1px solid #ccc;
+        border-radius: 5px;
+        padding: 10px;
+        font-size: 14px;
+        resize: vertical;
+      }
+      .button-container {
+        text-align: right;
+        margin-top: 10px;
+      }
+      button {
+        background-color: #4CAF50;
+        color: white;
+        border: none;
+        padding: 10px 20px;
+        border-radius: 5px;
+        cursor: pointer;
+        font-size: 14px;
+      }
+      button:hover {
+        background-color: #45a049;
+      }
+      #status {
+        margin-top: 10px;
+        color: #555;
+      }
+    </style>
+  </head>
+  <body>
+    <p>変更内容を複数行で記述できます。</p>
+    <textarea id="changesInput" placeholder="例: 
+- 新機能の追加
+- レイアウトの調整
+- バグの修正"></textarea>
+    <div class="button-container">
+      <button onclick="sendChanges()">出版</button>
+      <button onclick="google.script.host.close()">キャンセル</button>
+    </div>
+    <div id="status"></div>
+    <script>
+      function sendChanges() {
+        const changes = document.getElementById('changesInput').value;
+        const statusDiv = document.getElementById('status');
+        
+        // Google Apps Scriptの関数を呼び出してデータを渡す
+        google.script.run
+          .withSuccessHandler(function() {
+            statusDiv.textContent = '送信中です...';
+            google.script.host.close(); // 成功したらダイアログを閉じる
+          })
+          .withFailureHandler(function(error) {
+            statusDiv.textContent = 'エラーが発生しました: ' + error.message;
+          })
+          .processAndSend(changes);
+      }
+    </script>
+  </body>
+</html>

--- a/ChangesInput.html
+++ b/ChangesInput.html
@@ -34,6 +34,10 @@
       button:hover {
         background-color: #45a049;
       }
+      button:disabled {
+        background-color: #cccccc;
+        cursor: not-allowed;
+      }
       #status {
         margin-top: 10px;
         color: #555;
@@ -47,23 +51,30 @@
 - レイアウトの調整
 - バグの修正"></textarea>
     <div class="button-container">
-      <button onclick="sendChanges()">出版</button>
+      <button id="publishButton" onclick="sendChanges()">出版</button>
       <button onclick="google.script.host.close()">キャンセル</button>
     </div>
     <div id="status"></div>
     <script>
       function sendChanges() {
+        // 出版ボタンを取得し、処理中は無効にする
+        const publishButton = document.getElementById('publishButton');
+        publishButton.disabled = true;
+        publishButton.textContent = '送信中...'; // ボタンのテキストを変更してユーザーにフィードバック
+        
         const changes = document.getElementById('changesInput').value;
         const statusDiv = document.getElementById('status');
         
         // Google Apps Scriptの関数を呼び出してデータを渡す
         google.script.run
           .withSuccessHandler(function() {
-            statusDiv.textContent = '送信中です...';
+            statusDiv.textContent = '送信完了';
             google.script.host.close(); // 成功したらダイアログを閉じる
           })
           .withFailureHandler(function(error) {
             statusDiv.textContent = 'エラーが発生しました: ' + error.message;
+            publishButton.disabled = false; // エラー時はボタンを再度有効にする
+            publishButton.textContent = '出版';
           })
           .processAndSend(changes);
       }

--- a/README.md
+++ b/README.md
@@ -1,2 +1,36 @@
 # g-spreadsheetPublishBot
 Google Spreadsheet のシートを PDF にエクスポートし、 Webhook 経由で送信します
+
+## セットアップ
+### 1. スプレッドシートの `拡張機能` の `Apps Script` でプロジェクトの作成
+### 2. PDF保存用フォルダの作成
+Google Drive 上に、エクスポートされたPDFを保存するためのフォルダを作成します。作成したフォルダを起点に以下のような構成でファイルが保存されます。
+
+#### フォルダ構成例
+```
+${root folder name}/
+　├ ${yyyyMMdd_hhmm}/
+　│　└ ${sheet name} - ${yyyyMMdd_hhmmss}.pdf
+　│　└ [print]${sheet name} - ${yyyyMMdd_hhmmss}.pdf
+```
+※ `[print]` がついたPDFはモノクロバージョンです。
+
+#### 例
+```
+pdf/
+　├ 20250822_2214/
+　│　└ テスト - 20250822_221411.pdf
+　│　└ [print]テスト - 20250822_221411.pdf
+　├ 20250822_2234/
+　│　└ テスト - 20250822_223412.pdf
+　│　└ [print]テスト - 20250822_223412.pdf
+　└ ...
+```
+
+### 3. スクリプトプロパティの設定
+以下のプロパティを設定します。
+- `GOOGLE_CHAT_WEBHOOK_URL`: Google Chat の Webhook のURL
+- `PARENT_FOLDER_ID`: エクスポートされたPDFのフォルダが保存されるフォルダのID
+
+### 4. プログラムの配置
+本レポジトリに存在する全ての `.gs` ファイルをコピーし、Apps Scriptのプロジェクト内に同一ファイル名で貼り付け、保存します。


### PR DESCRIPTION
このプルリクエストでは、Google スプレッドシートを PDF として公開し、Google Chat に送信する前に変更内容を入力するための、ユーザーフレンドリーなダイアログが導入されます。また、ドキュメントを更新し、新しいダイアログと変更内容の処理を組み込むために、メインの公開フローをリファクタリングしました。

**ユーザーエクスペリエンスの改善:**
- 公開前に変更内容の複数行の入力を促すモーダルダイアログ (`ChangesInput.html`) を追加しました。このダイアログには、スタイル設定された入力、フィードバックメッセージが含まれており、処理のために Google Apps Script と統合されています。
- メインメニューオプションを選択すると、Google Chat にすぐに送信するのではなく、このダイアログが起動されるようになりました。これにより、ワークフローがよりインタラクティブで情報提供が充実します。

**公開フローのリファクタリング:**
- 以前の `publish_and_send_google_chat` 関数を `showChangesDialog` (ダイアログを表示) と `processAndSend` (入力された変更内容と公開ロジックを処理) に置き換えました。
- Google Chat に送信されるメッセージに、カラーおよびモノクロの PDF へのリンクに加えて、ユーザーが入力した変更内容の説明が含まれるようになりました。

**ドキュメントの更新:**
- `README.md` を拡張し、詳細なセットアップ手順、フォルダ構造の例、スクリプトのプロパティとファイルの配置に関する設定手順を追加しました。